### PR TITLE
Expose the open_connection: Uri.t -> channels function

### DIFF
--- a/lwt/xen_api_lwt_unix.mli
+++ b/lwt/xen_api_lwt_unix.mli
@@ -21,3 +21,12 @@ val make_json: ?timeout:float -> string -> Rpc.call -> Rpc.response Lwt.t
 	passed to Client.* functions *)
 
 include (module type of (Client.ClientF(Lwt)))
+
+module Lwt_unix_IO : sig
+
+  type ic = (unit -> unit Lwt.t) * Lwt_io.input_channel
+  type oc = (unit -> unit Lwt.t) * Lwt_io.output_channel
+
+  val open_connection: Uri.t -> ((ic * oc), exn) Xen_api.result Lwt.t
+end
+


### PR DESCRIPTION
This is needed for interacting with the streaming aspects of the API,
for example VM console streaming.

Signed-off-by: David Scott dave.scott@eu.citrix.com
