### PR TITLE
Metrics: allow the client to choose the granularity of the metrics

### DIFF
--- a/lib/xen_api_metrics.ml
+++ b/lib/xen_api_metrics.ml
@@ -58,6 +58,21 @@ module Legend = struct
       None
 end
 
+type interval = [
+  | `Seconds
+  | `Minute
+  | `Hour
+  | `Day
+  | `Other of int
+]
+
+let int_of_interval = function
+  | `Seconds -> 5
+  | `Minute -> 60
+  | `Hour -> 60 * 60
+  | `Day -> 24 * 60 * 60
+  | `Other x -> x
+
 module Updates = struct
 
   let uri ~host ~authentication ~start ?(include_host=false) ?interval ?cf () =
@@ -71,7 +86,7 @@ module Updates = struct
     let query = [
       "start", [ string_of_int start ];
       "host", [ string_of_bool include_host ]
-    ] @ (match interval with None -> [] | Some x -> [ "interval", [ string_of_int x ] ])
+    ] @ (match interval with None -> [] | Some x -> [ "interval", [ string_of_int (int_of_interval x) ] ])
       @ (match cf with None -> [] | Some x -> [ "cf", [ string_of_cf x ] ]) in
     let userinfo = match authentication with
     | `UserPassword (user, pass) -> Some (user ^ ":" ^ pass)

--- a/lib/xen_api_metrics.mli
+++ b/lib/xen_api_metrics.mli
@@ -35,12 +35,23 @@ module Legend : sig
       contains useful information such as the units. *)
 end
 
+type interval = [
+  | `Seconds (** every 5 seconds for 10 minutes *)
+  | `Minute  (** every minute for 2 hours *)
+  | `Hour    (** every hour for one week *)
+  | `Day     (** every day for one year *)
+  | `Other of int
+]
+(** Points are averaged over an interval and stored in separate 'archives'.
+    The server will automatically select an interval given a start time but
+    you can manually select the interval if you want a particular resolution. *)
+
 module Updates : sig
 
   val uri:
        host:Uri.t -> authentication:Xen_api_auth.t
     -> start:int -> ?include_host:bool
-    -> ?interval:int -> ?cf:cf
+    -> ?interval:interval -> ?cf:cf
     -> unit
     -> Uri.t
   (** [updates ~host ~authentication ~start ?include_host ?interval ?cf ()]

--- a/lwt_test/watch_metrics.ml
+++ b/lwt_test/watch_metrics.ml
@@ -21,6 +21,7 @@ let uri = ref "http://127.0.0.1/"
 let username = ref "root"
 let password = ref "password"
 let start = ref 0
+let interval = ref 5
 
 let exn_to_string = function
 	| Api_errors.Server_error(code, params) ->
@@ -39,7 +40,8 @@ let main () =
 			let open Cohttp_lwt_unix in
 			let uri = Xen_api_metrics.Updates.uri
 				~host:(Uri.of_string !uri) ~authentication:(`UserPassword(!username, !password))
-				~start:(Int64.to_int start) ~include_host:true () in
+				~start:(Int64.to_int start) ~interval:(`Other !interval)
+				~include_host:true () in
 			let b = Cohttp.Auth.string_of_credential (`Basic (!username, !password)) in
 			let headers = Cohttp.Header.of_list ["authorization", b] in
 
@@ -73,6 +75,7 @@ let _ =
 		"-u", Arg.Set_string username, (Printf.sprintf "Username to log in with (default %s)" !username);
 		"-pw", Arg.Set_string password, (Printf.sprintf "Password to log in with (default %s)" !password);
 		"-start", Arg.Set_int start, (Printf.sprintf "Time since epoc to fetch updates from (default %d)" !start);
+    "-interval", Arg.Set_int interval, (Printf.sprintf "Preferred sampling interval (default %d)" !interval);
 	] (fun x -> Printf.fprintf stderr "Ignoring argument: %s\n" x)
 		"Simple example which watches metrics updates from a host";
 


### PR DESCRIPTION
The granularity is determined by the interval between datapoints.

Signed-off-by: David Scott <dave.scott@citrix.com>