### PR TITLE
CP-9895: Added originator for xapi login_with_password

### DIFF
--- a/async_test/list_vms.ml
+++ b/async_test/list_vms.ml
@@ -29,7 +29,7 @@ let exn_to_string = function
 
 let main () =
 	let rpc = make !uri in
-	Session.login_with_password rpc !username !password "1.0"
+	Session.login_with_password rpc !username !password "1.0" "async-test"
 	>>= fun session_id ->
 	VM.get_all_records rpc session_id
 	>>= fun vms ->

--- a/event_test/event_test.ml
+++ b/event_test/event_test.ml
@@ -111,7 +111,7 @@ let watch_events rpc session_id =
 
 let main () =
 	let rpc = make !uri in
-	Session.login_with_password rpc !username !password "1.0"
+	Session.login_with_password rpc !username !password "1.0" "event-test"
 	>>= fun session_id ->
         let a = watch_events rpc session_id in
         let b = watch_events rpc session_id in

--- a/lib/aPI.ml
+++ b/lib/aPI.ml
@@ -921,7 +921,7 @@ module type API = sig
     val set_other_config : rpc:(Rpc.call -> Rpc.response) -> session_id:ref_session -> self:ref_session -> value:string_to_string_map -> unit
     val add_to_other_config : rpc:(Rpc.call -> Rpc.response) -> session_id:ref_session -> self:ref_session -> key:string -> value:string -> unit
     val remove_from_other_config : rpc:(Rpc.call -> Rpc.response) -> session_id:ref_session -> self:ref_session -> key:string -> unit
-    val login_with_password : rpc:(Rpc.call -> Rpc.response) -> uname:string -> pwd:string -> version:string -> ref_session
+    val login_with_password : rpc:(Rpc.call -> Rpc.response) -> uname:string -> pwd:string -> version:string -> originator:string -> ref_session
     val logout : rpc:(Rpc.call -> Rpc.response) -> session_id:ref_session -> unit
     val change_password : rpc:(Rpc.call -> Rpc.response) -> session_id:ref_session -> old_pwd:string -> new_pwd:string -> unit
     val slave_login : rpc:(Rpc.call -> Rpc.response) -> host:ref_host -> psecret:string -> ref_session

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -2565,12 +2565,13 @@ module ClientF = functor(X : IO) ->struct
       
       rpc_wrapper rpc "session.remove_from_other_config" [ session_id; self; key ] >>= fun x -> return (ignore x)
     (**  *)
-    let login_with_password ~rpc ~uname ~pwd ~version =
+    let login_with_password ~rpc ~uname ~pwd ~version ~originator =
       let uname = rpc_of_string uname in
       let pwd = rpc_of_string pwd in
       let version = rpc_of_string version in
+      let originator = rpc_of_string originator in
       
-      rpc_wrapper rpc "session.login_with_password" [ uname; pwd; version ] >>= fun x -> return (ref_session_of_rpc  x)
+      rpc_wrapper rpc "session.login_with_password" [ uname; pwd; version; originator ] >>= fun x -> return (ref_session_of_rpc  x)
     (**  *)
     let logout ~rpc ~session_id =
       let session_id = rpc_of_ref_session session_id in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -10,7 +10,7 @@ let testrpc x =
 			Lwt.return (Xml.parse_string r.content)
 
 let _ =
-	Client.Session.login_with_password testrpc "root" "xenroot" "1.0" >>= fun x ->
+	Client.Session.login_with_password testrpc "root" "xenroot" "1.0" "test.ml" >>= fun x ->
 	Client.VM.get_all_records testrpc x >>= fun l ->
 	Firebug.console##log (Js.string (Printf.sprintf "Length=%d" (List.length l)));
 	Lwt.return ()

--- a/lib_test/xen_api_test.ml
+++ b/lib_test/xen_api_test.ml
@@ -110,7 +110,7 @@ let test_login_fail _ =
 	num_sleeps := 0;
 	begin
 		try
-			let session_id = C.Session.login_with_password rpc "root" "password" "1.0" in
+			let session_id = C.Session.login_with_password rpc "root" "password" "1.0" "xen-api-test.ml" in
 			()
 		with Xen_api.No_response -> ()
 	end;
@@ -141,7 +141,7 @@ let test_login_success _ =
 		>>= function
 			| Ok x -> Xmlrpc.response_of_string x
 			| Error e -> raise e in
-	let session_id' = C.Session.login_with_password rpc "root" "password" "1.0" in
+	let session_id' = C.Session.login_with_password rpc "root" "password" "1.0" "xen-api-test.ml" in
 	assert_equal ~msg:"session_id" session_id session_id'
 
 let _ =

--- a/lwt_test/list_vms.ml
+++ b/lwt_test/list_vms.ml
@@ -29,7 +29,7 @@ let exn_to_string = function
 
 let main () =
 	let rpc = if !json then make_json !uri else make !uri in
-	lwt session_id = Session.login_with_password rpc !username !password "1.0" in
+	lwt session_id = Session.login_with_password rpc !username !password "1.0" "list-vms" in
 	try_lwt
 		lwt vms = VM.get_all_records rpc session_id in
 		List.iter

--- a/lwt_test/upload_disk.ml
+++ b/lwt_test/upload_disk.ml
@@ -30,7 +30,7 @@ let main filename =
 	Lwt_unix.LargeFile.stat filename >>= fun stats ->
 	let virtual_size = stats.Lwt_unix.LargeFile.st_size in
 	let rpc = make !uri in
-	lwt session_id = Session.login_with_password rpc !username !password "1.0" in
+	lwt session_id = Session.login_with_password rpc !username !password "1.0" "upload-disk" in
 	try_lwt
 		lwt pools = Pool.get_all rpc session_id in
 		let pool = List.hd pools in


### PR DESCRIPTION
The login_with_password XenAPI call takes an "originator"
string as its fourth parameter.

If a client does this, then it gets its own pool of xapi sessions.
Moreover it will not have its xapi sessions destroyed prematurely
as a result of some other misbehaving client that keeps creating
sessions and not logging out of them.

This patch adds the "originator" to all invokes of
login_with_password.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>