### PR TITLE
Update Travis configuration, add coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   global:
     - OCAML_VERSION=4.02
     - PACKAGE=xen-api-client
+    # WARNING: Don't set TESTS=true here (which is the default) as that env var
+    # is already used by the Makefile for OASIS configuration.
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam XS_COV=1
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
-sudo: true
+sudo: required
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+  - wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
+script:
+  - bash -ex .travis-opam.sh
+  - if [ ! -z "${XS_COV}" ]; then bash -ex travis-coveralls.sh || true; fi
 env:
-        - OCAML_VERSION=4.02 PACKAGE=xen-api-client
+  global:
+    - OCAML_VERSION=4.02
+    - PACKAGE=xen-api-client
+  matrix:
+    - BASE_REMOTE=git://github.com/xapi-project/xs-opam XS_COV=1
+    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 Ocaml client for the Xen API.
+[![Build Status](https://travis-ci.org/gaborigloi/xen-api-client.svg?branch=master)](https://travis-ci.org/gaborigloi/xen-api-client)
 
 Depends on: Xmlm, Lwt, SSL
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Ocaml client for the Xen API.
 [![Build Status](https://travis-ci.org/gaborigloi/xen-api-client.svg?branch=master)](https://travis-ci.org/gaborigloi/xen-api-client)
+[![Coverage Status](https://coveralls.io/repos/github/xapi-project/xen-api-client/badge.svg?branch=master)](https://coveralls.io/github/xapi-project/xen-api-client?branch=master)
 
 Depends on: Xmlm, Lwt, SSL
 

--- a/opam
+++ b/opam
@@ -15,6 +15,9 @@ tags: [
 build: [
   [make]
 ]
+build-test: [
+  [make "test"]
+]
 install: [
   [make "install"]
 ]


### PR DESCRIPTION
The .travis.yml file is modeled after that of xcp-idl and message-switch. For some reason coveralls does not display statistics by file/line, but it displays the overall coverage.