### PR TITLE
Fix Travis badge URL in README.md -.-

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-Ocaml client for the Xen API.
-[![Build Status](https://travis-ci.org/gaborigloi/xen-api-client.svg?branch=master)](https://travis-ci.org/gaborigloi/xen-api-client)
+[![Build Status](https://travis-ci.org/xapi-project/xen-api-client.svg?branch=master)](https://travis-ci.org/xapi-project/xen-api-client)
 [![Coverage Status](https://coveralls.io/repos/github/xapi-project/xen-api-client/badge.svg?branch=master)](https://coveralls.io/github/xapi-project/xen-api-client?branch=master)
+
+Ocaml client for the Xen API.
 
 Depends on: Xmlm, Lwt, SSL
 


### PR DESCRIPTION
And move badges to the top of the README.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>