### PR TITLE
CA-267957: open_connection: only close fd once

### DIFF
--- a/lwt/xen_api_lwt_unix.ml
+++ b/lwt/xen_api_lwt_unix.ml
@@ -97,7 +97,7 @@ module Lwt_unix_IO = struct
            Lwt_ssl.ssl_connect fd sslctx >>= fun sock ->
            let ic = Lwt_ssl.in_channel_of_descr sock in
            let oc = Lwt_ssl.out_channel_of_descr sock in
-           return (Ok (((fun () -> Lwt_ssl.close sock), ic), ((fun () -> Lwt_ssl.close sock), oc))))
+           return (Ok ((return, ic), ((fun () -> Lwt_ssl.close sock), oc))))
         (fun e -> return (Error e))
     end else begin
       let fd = Lwt_unix.socket domain Unix.SOCK_STREAM 0 in


### PR DESCRIPTION
One call to Lwt_ssl.close is sufficient to close the fd.

Since the 'close' function calls the functions associated with both ic and oc,
there's no need for both functions to call Lwt_ssl.close. Indeed, doing this
provokes an EBADF to be raised.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>