### PR TITLE
CA-268474: Introduce automatic api regeneration mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build/
 .merlin
 *.install
+.xapi/

--- a/.ref_replacement
+++ b/.ref_replacement
@@ -1,0 +1,95 @@
+module type REF = sig
+  type 'a t
+
+  val ref_prefix : string
+  val make : unit -> 'a t
+  val null : 'a t
+  val string_of : 'a t -> string
+  val of_string : string -> 'a t
+
+  val make_dummy : string -> 'a t
+  val is_dummy : 'a t -> bool
+  val name_of_dummy : 'a t -> string
+  val pretty_string_of_dummy : 'a t -> string
+  val really_pretty_and_small : 'a t -> string
+
+  val rpc_of_t: 'b -> 'a t -> Rpc.t
+  val t_of_rpc: 'b -> Rpc.t -> 'a t
+end
+module Ref: REF = struct
+  (* BEGIN ref.ml from xen-api repository *)
+  type 'a t = string
+
+  let ref_prefix = "OpaqueRef:"
+
+  let make () =
+    let uuid = Uuidm.v `V4 |> Uuidm.to_string in
+    ref_prefix ^ uuid
+
+  let null = ref_prefix ^ "NULL"
+
+  let string_of x = x
+
+  let of_string x = x
+
+  (* very ugly hack to be able to distinguish dummy and real tasks. Moreover, dummy tasks have their name *)
+  (* embedded into the reference .... *)
+
+  (* a dummy reference is a reference of an object which is not in database *)
+  let dummy_sep = "|"
+  let dummy_prefix = "DummyRef:"
+
+
+  let make_dummy task_name =
+    let uuid = Uuidm.v `V4 |> Uuidm.to_string in
+    dummy_prefix ^ dummy_sep ^ uuid ^ dummy_sep ^ task_name
+
+  let is_dummy x =
+    Astring.String.is_prefix ~affix:dummy_prefix x
+
+  let cut_in_three ~sep str =
+    let (>>=) opt f =
+      match opt with
+      | Some value -> f value
+      | None -> None
+    in
+    let open Astring in
+    String.cut ~sep str
+    >>= fun (head, tail) ->
+    String.cut ~sep tail
+    >>= fun (head', tail) ->
+    Some (head, head', tail)
+
+  let name_of_dummy x =
+    match cut_in_three ~sep:dummy_sep x with
+    | Some(_, _, name) -> name
+    | None -> failwith (
+        Printf.sprintf "Ref.name_of_dummy: %s is not a valid dummy reference" x)
+
+  (* we do not show the name when we pretty print the dummy reference *)
+  let pretty_string_of_dummy x =
+    match cut_in_three ~sep:dummy_sep x with
+    | Some (_, uuid, _) -> dummy_prefix ^ uuid
+    | None -> failwith (
+        Printf.sprintf "Ref.pretty_string_of_dummy: %s is not a valid dummy reference" x)
+
+  let really_pretty_and_small x =
+    let s, prelen, c =
+      if is_dummy x then
+        (pretty_string_of_dummy x, String.length dummy_prefix, 'D')
+      else
+        (string_of x, String.length ref_prefix, 'R')
+    in
+    try
+      let r = Bytes.create 14 in
+      Bytes.set r 0 c; Bytes.set r 1 ':';
+      for i = 0 to 7 do Bytes.set r (i + 2) s.[prelen + i]; done;
+      for i = 0 to 3 do Bytes.set r (i + 10)  s.[prelen + 8 + 1 + i]; done;
+      r
+    with _ ->
+      s
+  (* END ref.ml from xen-api repository *)
+
+  let rpc_of_t _ x = rpc_of_string (string_of x)
+  let t_of_rpc _ x = of_string (string_of_rpc x);
+end

--- a/.update_api.py
+++ b/.update_api.py
@@ -1,0 +1,68 @@
+from __future__ import print_function
+import itertools
+
+if __name__ != "__main__":
+    import sys
+    sys.exit("This should never be imported as a library")
+
+# Replace module Ref, drop module Legacy and remove Stdext from aPI.ml
+with open('lib/aPI.ml', 'r') as api_f:
+    api_lines = api_f.readlines()
+
+with open('.ref_replacement', 'r') as ref_f:
+    ref_replacement = ref_f.readlines()[:-1]  # 'end\n' is already in the tail
+
+
+api_head = list(
+    itertools.takewhile(lambda line: "module Ref" not in line,
+                        api_lines)
+)
+
+api_tail = itertools.takewhile(
+    lambda line: "module Legacy" not in line,
+    itertools.dropwhile(lambda line: not line.startswith('end'),
+                        api_lines[len(api_head):])
+)
+
+api = itertools.ifilter(
+    lambda line: "Stdext" not in line,
+    itertools.chain(api_head, ref_replacement, api_tail)
+)
+
+with open('lib/aPI.ml', 'w') as api_f:
+    api_f.writelines(api)
+    api_f.flush()
+
+# Drop unneeded stdext from event_types.ml
+
+with open('lib/event_types.ml', 'r') as event_f:
+    event_lines = event_f.readlines()
+
+event = itertools.ifilter(
+    lambda line: "Stdext" not in line,
+    event_lines
+)
+
+with open('lib/event_types.ml', 'w') as event_f:
+    event_f.writelines(event)
+    event_f.flush()
+
+# Update Ref in event_helper
+with open('lib/event_helper.ml', 'r') as event_f:
+    event_lines = event_f.readlines()
+
+event_head = list(
+    itertools.takewhile(
+        lambda line: line.strip() != "",
+        event_lines
+    ))
+
+event = itertools.chain(event_head,
+                        "module Ref = API.Ref",
+                        event_lines[len(event_head):]
+                        )
+
+with open('lib/event_helper.ml', 'w') as event_f:
+    event_f.writelines(event)
+    event_f.flush()
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build release install uninstall clean test doc reindent
+URL ?= https://github.com/xapi-project/xen-api
+BRANCH ?= master
+
+.PHONY: build release async-examples lwt-examples install uninstall clean test doc reindent regenerate
 
 build:
 	jbuilder build @install --dev
@@ -34,3 +37,23 @@ gh-pages:
 reindent:
 	git ls-files '*.ml' '*.mli' | xargs ocp-indent --syntax cstruct -i
 
+regenerate-files:
+	opam install --deps-only xapi -y
+	git clone --single-branch --branch $(BRANCH) $(URL) .xapi
+	# Generate and copy over files
+	cd .xapi ; \
+	jbuilder build _build/default/ocaml/idl/ocaml_backend/gen_api_main.exe ; \
+	cp ocaml/xapi-consts/api_errors.ml   ../lib/api_errors.ml   ; \
+	cp ocaml/xapi-consts/api_messages.ml ../lib/api_messages.ml ; \
+	cp ocaml/xapi-client/event_helper.ml ../lib/event_helper.ml ; \
+	cp ocaml/xapi-types/event_types.ml   ../lib/event_types.ml  ; \
+	_build/default/ocaml/idl/ocaml_backend/gen_api_main.exe  -mode api -filterinternal true -filter closed > aPI.ml       ; \
+	_build/default/ocaml/idl/ocaml_backend/gen_api_main.exe  -mode client -filterinternal true -filter closed > client.ml ; \
+	cp aPI.ml    ../lib/aPI.ml    ; \
+	cp client.ml ../lib/client.ml
+	# Update definitions in aPI.ml and drop stdext
+	python2 .update_api.py
+	# cleanup
+	rm -rf .xapi
+
+regenerate: regenerate-files reindent

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 [![Build Status](https://travis-ci.org/xapi-project/xen-api-client.svg?branch=master)](https://travis-ci.org/xapi-project/xen-api-client)
 [![Coverage Status](https://coveralls.io/repos/github/xapi-project/xen-api-client/badge.svg?branch=master)](https://coveralls.io/github/xapi-project/xen-api-client?branch=master)
 
-Ocaml client for the Xen API.
+Ocaml client for the Xen API and bindings for `lwt` and `async`.
 
-Depends on: Xmlm, Lwt, SSL
+Check out the examples in `lwt_examples` and `async_examples`. They can be built with `make lwt-examples` or `make async-examples`.
 
-Check out the example in: lwt_test/list_vms.ml
+API bindings can be updated to specific versions of xapi by running
 
+```
+# This assumes a fully working opam environment
+URL=xapi/gihub/repo BRANCH=branch-name make regenerate
+```
 
+By default `URL=https://github.com/xapi-project/xen-api` and `BRANCH=master` when running `make regenerate`.


### PR DESCRIPTION
I am not pushing updated API from Travis builds on purpose. This would require multiple versions per day and it's going to be a nightmare to maintain.

The long term project is to make `xen-api-client` swappable with `xapi-client`.