### PR TITLE
Remove unused cstruct.lwt dependency

### DIFF
--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -4,7 +4,6 @@
   (libraries
    (cohttp
     cstruct
-    cstruct.lwt
     lwt
     lwt.ssl
     lwt.unix

--- a/xen-api-client-lwt.opam
+++ b/xen-api-client-lwt.opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "astring"
   "cohttp" {>= "0.12.0" & < "0.22.0"}
-  "cstruct" {>= "1.0.1" & < "3.0.0"}
+  "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "re"
   "rpc" {>= "1.9.51"}


### PR DESCRIPTION
Since we only depend on cstruct here, this library is compatible with
the 3.X versions of cstruct, because we don't depend on the new
cstruct-lwt OPAM package that has been split from the cstruct package.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>