### PR TITLE
Move to dune and fix opam dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.04.2
+    - OCAML_VERSION=4.06
     - PINS="xen-api-client:. xen-api-client-lwt:. xen-api-client-async:."
     - PACKAGE=xen-api-client
     - DISTRO="ubuntu-14.04"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
 env:
   global:
     - OCAML_VERSION=4.04.2
-    - PINS="xen-api-client:."
+    - PINS="xen-api-client:. xen-api-client-lwt:. xen-api-client-async:."
     - PACKAGE=xen-api-client
     - DISTRO="ubuntu-14.04"
   matrix:

--- a/Makefile
+++ b/Makefile
@@ -7,32 +7,32 @@ BRANCH ?= master
 .PHONY: release build async-examples lwt-examples install uninstall clean test doc reindent regenerate
 
 release:
-	jbuilder build @install
+	dune build @install --profile=release
 
 build:
-	jbuilder build @install --dev
+	dune build @install
 
 async-examples:
-	jbuilder build @async_examples/examples
+	dune build @async_examples/examples
 
 lwt-examples:
-	jbuilder build @lwt_examples/examples
+	dune build @lwt_examples/examples
 
 install:
-	jbuilder install --prefix=$(OPAM_PREFIX) --libdir=$(OPAM_LIBDIR)
+	dune install --prefix=$(OPAM_PREFIX) --libdir=$(OPAM_LIBDIR)
 
 uninstall:
-	jbuilder uninstall --prefix=$(OPAM_PREFIX) --libdir=$(OPAM_LIBDIR)
+	dune uninstall --prefix=$(OPAM_PREFIX) --libdir=$(OPAM_LIBDIR)
 
 clean:
-	jbuilder clean
+	dune clean
 
 test:
-	jbuilder runtest
+	dune runtest
 
 # requires odoc
 doc:
-	jbuilder build @doc
+	dune build @doc
 
 gh-pages:
 	bash .docgen.sh

--- a/xen-api-client-async.opam
+++ b/xen-api-client-async.opam
@@ -12,15 +12,18 @@ tags: [
   "org:xapi-project"
 ]
 
-build: [[ "jbuilder" "build" "-p" name ]]
+build: [[ "dune" "build" "-p" name ]]
 
 depends: [
-  "jbuilder" {build & >= "1.0+beta11"}
-  "astring"
+  "dune" {build}
   "async" {>= "v0.9.0"}
+  "async_unix"
+  "base-threads"
   "cohttp" {>= "0.22.0"}
-  "rpc" {>= "1.9.52"}
+  "core"
+  "rpclib"
   "uri"
   "xen-api-client"
   "xmlm"
+  "ounit" {test}
 ]

--- a/xen-api-client-lwt.opam
+++ b/xen-api-client-lwt.opam
@@ -12,20 +12,18 @@ tags: [
   "org:xapi-project"
 ]
 
-build: [[ "jbuilder" "build" "-p" name ]]
+build: [[ "dune" "build" "-p" name ]]
 
 depends: [
-  "jbuilder" {build & >= "1.0+beta11"}
-  "astring"
-  "cohttp" {>= "0.22.0"}
-  "cstruct" {>= "1.0.1"}
-  "lwt" {>= "3.0.0"}
-  "lwt_ssl"
-  "re"
-  "rpc" {>= "1.9.51"}
-  "ssl"
-  "uri"
-  "uuidm"
-  "xen-api-client"
-  "xmlm"
+    "dune" {build}
+    "cohttp" {>= "0.22.0"}
+    "cstruct" {>= "1.0.1"}
+    "lwt" {>= "3.0.0"}
+    "lwt_ssl"
+    "re"
+    "rpclib"
+    "uri"
+    "xen-api-client"
+    "xmlm"
+    "ounit" {test}
 ]

--- a/xen-api-client.opam
+++ b/xen-api-client.opam
@@ -12,20 +12,20 @@ tags: [
   "org:xapi-project"
 ]
 
-build: [[ "jbuilder" "build" "-p" name ]]
-build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+build: [[ "dune" "build" "-p" name ]]
+build-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 
 depends: [
-  "jbuilder" {build & >= "1.0+beta11"}
-  "astring"
-  "cohttp" {>= "0.22.0"}
-  "ounit" {test}
-  "re"
-  "rpc" {>= "1.9.51"}
-  "uri"
-  "uuidm"
-  "xapi-client"
-  "xapi-rrd"
-  "xapi-types"
-  "xmlm"
+    "dune" {build & >= "1.0+beta11"}
+    "astring"
+    "cohttp" {>= "0.22.0"}
+    "re"
+    "rpclib"
+    "rrd"
+    "uri"
+    "uuidm"
+    "xapi-client"
+    "xapi-types"
+    "xmlm"
+    "ounit" {test}
 ]


### PR DESCRIPTION
We were depending on `rpc` in opam, but actually using `rpclib`.
This had the undesired effect of installing both Async and Lwt, when
a dependency only asked for one but not the other.
The dependencies should be more fine grained now.

The opam dependencies were created based on output from:
`dune external-lib-deps -p <pkg> @install @runtest`

Signed-off-by: Edwin Török <edvin.torok@citrix.com>