### PR TITLE
CP-32846 drop legacy ssl support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,14 @@
 language: c
-sudo: required
+service: docker
 install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
-  - wget https://raw.githubusercontent.com/xapi-project/xapi-travis-scripts/master/coverage.sh
-script:
-  - bash -ex .travis-docker.sh
-services:
-  - docker
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
+script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.07
     - PINS="xen-api-client:. xen-api-client-lwt:. xen-api-client-async:."
+  jobs:
     - PACKAGE=xen-api-client
-    - DISTRO="debian-9"
-  matrix:
-    - BASE_REMOTE=git://github.com/xapi-project/xs-opam \
-        POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
-    - PACKAGE=xen-api-client-async BASE_REMOTE=git://github.com/xapi-project/xs-opam POST_INSTALL_HOOK="make async-examples"
-    - PACKAGE=xen-api-client-lwt BASE_REMOTE=git://github.com/xapi-project/xs-opam POST_INSTALL_HOOL="make lwt-examples"
-    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+    - PACKAGE=xen-api-client-async POST_INSTALL_HOOK="make async-examples"
+    - PACKAGE=xen-api-client-lwt POST_INSTALL_HOOK="make lwt-examples"

--- a/lwt/cohttp_unbuffered_io.ml
+++ b/lwt/cohttp_unbuffered_io.ml
@@ -43,7 +43,7 @@ type conn = Data_channel.t
 let really_read_into c buf ofs len =
   let tmp = Cstruct.create len in
   c.Data_channel.really_read tmp >>= fun () ->
-  Cstruct.blit_to_string tmp 0 buf ofs len;
+  Cstruct.blit_to_bytes tmp 0 buf ofs len;
   return ()
 
 let read_http_headers c =

--- a/lwt/data_channel.ml
+++ b/lwt/data_channel.ml
@@ -67,7 +67,7 @@ let of_fd fd ~seekable = (if seekable then of_seekable_fd else of_unseekable_fd)
 
 let sslctx =
   Ssl.init ();
-  Ssl.create_context Ssl.SSLv23 Ssl.Client_context
+  Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context
 
 let of_ssl_fd fd =
   Lwt_ssl.ssl_connect fd sslctx >>= fun sock ->

--- a/lwt/xen_api_lwt_unix.ml
+++ b/lwt/xen_api_lwt_unix.ml
@@ -59,7 +59,7 @@ module Lwt_unix_IO = struct
 
   let sslctx =
     Ssl.init ();
-    Ssl.create_context Ssl.SSLv23 Ssl.Client_context
+    Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context
 
   let open_connection uri =
     let domain_addr_t = match Uri.host uri with

--- a/lwt_examples/dune
+++ b/lwt_examples/dune
@@ -22,7 +22,7 @@
   (name watch_metrics)
   (modules watch_metrics)
   (libraries
-    cohttp.lwt
+    cohttp-lwt-unix
     lwt
     lwt.unix
     xen-api-client

--- a/xen-api-client-lwt.opam
+++ b/xen-api-client-lwt.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml"
   "dune" {build}
   "cohttp" {>= "0.22.0"}
+  "cohttp-lwt-unix"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "3.0.0"}
   "lwt_ssl"


### PR DESCRIPTION
Use TLS v1.2 instead of deprecated SSL

Signed-off-by: lippirk <ben.anson@citrix.com>